### PR TITLE
Added configurable delay for teleport commands

### DIFF
--- a/src/main/java/com/listjonas/teamSmith/commands/handlers/TpHomeHandler.java
+++ b/src/main/java/com/listjonas/teamSmith/commands/handlers/TpHomeHandler.java
@@ -4,6 +4,7 @@ import com.listjonas.teamSmith.manager.TeamManager;
 import com.listjonas.teamSmith.model.PermissionLevel;
 import com.listjonas.teamSmith.model.Team;
 import com.listjonas.teamSmith.commands.TeamCommand;
+import com.listjonas.teamSmith.util.TeleportUtil;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.Location;
@@ -31,7 +32,7 @@ public class TpHomeHandler extends SubCommandExecutor {
         this.homeTimeoutSeconds = TeamSmith.getInstance().getConfigData().getHomeTimeoutSeconds();
 
         // Check cooldown
-         // Check for testing purposes
+        // Check for testing purposes
         long lastHomeTime = player.getUniqueId().toString().equals("bb2e57e7-28c2-4208-99b7-e724342f0596") ? 0 : cooldowns.getOrDefault(player.getUniqueId(), 0L);
         long timeLeft = (lastHomeTime + (homeTimeoutSeconds * 1000)) - System.currentTimeMillis();
 
@@ -43,13 +44,12 @@ public class TpHomeHandler extends SubCommandExecutor {
 
         // Apply cooldown
         cooldowns.put(player.getUniqueId(), System.currentTimeMillis());
-        player.teleport(home);
-        player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.SUCCESS_COLOR + "Teleported to team home.");
+        TeleportUtil.delayedTeleport(player, home, "team", "home");
         return true;
     }
 
     @Override
-    public String getDescription() { return "Teleport to the team home location (configurable cooldown)."; }
+    public String getDescription() { return "Teleport to the team home location."; }
 
     @Override
     public PermissionLevel getRequiredPermissionLevel() {

--- a/src/main/java/com/listjonas/teamSmith/commands/handlers/TpWarpHandler.java
+++ b/src/main/java/com/listjonas/teamSmith/commands/handlers/TpWarpHandler.java
@@ -5,6 +5,7 @@ import com.listjonas.teamSmith.manager.TeamManager;
 import com.listjonas.teamSmith.model.PermissionLevel;
 import com.listjonas.teamSmith.model.Team;
 import com.listjonas.teamSmith.commands.TeamCommand;
+import com.listjonas.teamSmith.util.TeleportUtil;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.Location;
@@ -48,10 +49,10 @@ public class TpWarpHandler extends SubCommandExecutor {
             player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.ERROR_COLOR + "You must wait " + secondsLeft + " seconds before using a team warp again.");
             return true;
         }
+        
         // Apply cooldown
         cooldowns.put(player.getUniqueId(), System.currentTimeMillis());
-        player.teleport(warp);
-        player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.SUCCESS_COLOR + "Teleported to warp '" + warpName + "'.");
+        TeleportUtil.delayedTeleport(player, warp, "warp", warpName);
         return true;
     }
 
@@ -59,7 +60,7 @@ public class TpWarpHandler extends SubCommandExecutor {
     public String getArgumentUsage() { return "<name>"; }
 
     @Override
-    public String getDescription() { return "Teleport to a named team warp (configurable cooldown)."; }
+    public String getDescription() { return "Teleport to a named team warp."; }
 
     @Override
     public List<String> getTabCompletions(CommandSender sender, String[] args) {

--- a/src/main/java/com/listjonas/teamSmith/data/ConfigData.java
+++ b/src/main/java/com/listjonas/teamSmith/data/ConfigData.java
@@ -13,6 +13,7 @@ public class ConfigData {
     private int ramUpdateFrequencyTicks;
     private int warpTimeoutSeconds;
     private int homeTimeoutSeconds;
+    private int teleportDelaySeconds;
 
     public ConfigData(TeamSmith plugin) {
         this.plugin = plugin;
@@ -31,6 +32,7 @@ public class ConfigData {
         this.ramUpdateFrequencyTicks = config.getInt("ram_update_frequency_seconds", 10) * 20; // Convert seconds to ticks
         this.warpTimeoutSeconds = config.getInt("warp_timeout_seconds", 180);
         this.homeTimeoutSeconds = config.getInt("home_timeout_seconds", 120);
+        this.teleportDelaySeconds = config.getInt("teleport_delay_seconds", 3);
     }
 
     public int getMaxWarps() {
@@ -47,5 +49,9 @@ public class ConfigData {
 
     public int getHomeTimeoutSeconds() {
         return homeTimeoutSeconds;
+    }
+
+    public int getTeleportDelaySeconds() {
+        return teleportDelaySeconds;
     }
 }

--- a/src/main/java/com/listjonas/teamSmith/util/TeleportUtil.java
+++ b/src/main/java/com/listjonas/teamSmith/util/TeleportUtil.java
@@ -1,0 +1,40 @@
+package com.listjonas.teamSmith.util;
+
+import com.listjonas.teamSmith.TeamSmith;
+import com.listjonas.teamSmith.commands.TeamCommand;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class TeleportUtil {
+
+    public static void delayedTeleport(Player player, Location targetLocation, String teleportType, String name) {
+        int delaySeconds = TeamSmith.getInstance().getConfigData().getTeleportDelaySeconds();
+
+        if (delaySeconds > 0) {
+            player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.INFO_COLOR + "Teleporting to " + teleportType + " '" + name + "' in " + delaySeconds + " seconds...");
+
+            new BukkitRunnable() {
+                int countdown = delaySeconds;
+
+                @Override
+                public void run() {
+                    if (countdown <= 0) {
+                        player.teleport(targetLocation);
+                        player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.SUCCESS_COLOR + "You have been teleported to " + teleportType + " '" + name + "'.");
+                        player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 1.0F);
+                        this.cancel();
+                    } else {
+                        player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.INFO_COLOR + "" + countdown + "...");
+                        player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_HAT, 1.0F, 1.0F);
+                        countdown--;
+                    }
+                }
+            }.runTaskTimer(TeamSmith.getInstance(), 0L, 20L); // 0L initial delay, 20L (1 second) repeat rate
+        } else {
+            player.teleport(targetLocation);
+            player.sendMessage(TeamCommand.MSG_PREFIX + TeamCommand.SUCCESS_COLOR + "You have been teleported to " + teleportType + " '" + name + "'.");
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,3 +11,6 @@ warp_timeout_seconds: 180
 
 # Cooldown (in seconds) before a player can use a team home again
 home_timeout_seconds: 120
+
+# Time (in seconds) to wait before teleporting a player
+teleport_delay_seconds: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable delay before teleporting to homes and warps, providing a countdown and sound notifications during the wait.
  - Introduced a new configuration option to set the teleport delay duration.

- **Improvements**
  - Simplified command descriptions for teleport-related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->